### PR TITLE
Fix and enhance: Avatar fallback, role customization, and embed announcements

### DIFF
--- a/src/commands/eventsmode/panel.ts
+++ b/src/commands/eventsmode/panel.ts
@@ -11,6 +11,7 @@ import {
   VoiceChannel,
   time,
   bold,
+  roleMention,
   TextChannel,
   Message,
 } from 'discord.js';
@@ -434,12 +435,20 @@ export class Command {
           linkButton,
         );
 
-        const embed = safeJsonParse(event.announcedEmbed, {
+        const safeJsonEmbed = safeJsonParse(event.announcedEmbed, {
           content: BotMessages.SOMETHING_GONE_WRONG,
         });
 
+        const embed = new EmbedBuilder(...safeJsonEmbed.embeds);
+
         const message = await eventAnnounceChannel
-          .send({ ...embed, components: [row] })
+          .send({
+            content: guild.settingsManagement.announcementRoleId
+              ? roleMention(guild.settingsManagement.announcementRoleId)
+              : '',
+            embeds: [embed],
+            components: [row],
+          })
           .catch(logger.error);
 
         if (message instanceof Message) {

--- a/src/commands/eventsmode/profile.ts
+++ b/src/commands/eventsmode/profile.ts
@@ -67,7 +67,9 @@ export class Command {
     const buffer = await generateCanvasProfile({
       user: {
         nickname: author.user.username,
-        avatar: author.user.avatarURL({ forceStatic: true, size: 2048 }) ?? '',
+        avatar:
+          author.user.avatarURL({ forceStatic: true, size: 2048 }) ??
+          'https://imgur.com/dbTZKs0.png',
         staffRole: getStuffRole(eventsmode.staffRole),
       },
       stats: {

--- a/src/commands/moderator/setup.ts
+++ b/src/commands/moderator/setup.ts
@@ -55,9 +55,28 @@ export class Command {
 
   @ButtonComponent({ id: '@button/roles-configure' })
   async roleHandler(ctx: ButtonInteraction<'cached'>) {
+    const buttonRow = [
+      new ActionRowBuilder<MessageActionRowComponentBuilder>().addComponents(
+        new ButtonBuilder()
+          .setLabel(`staff`)
+          .setStyle(ButtonStyle.Secondary)
+          .setCustomId('@button/staff-roles-configure'),
+        new ButtonBuilder()
+          .setLabel(`secondary`)
+          .setStyle(ButtonStyle.Secondary)
+          .setCustomId('@button/secondary-roles-configure'),
+      ),
+    ];
+
+    await ctx.reply({ components: buttonRow, ephemeral: true });
+    return;
+  }
+
+  @ButtonComponent({ id: '@button/staff-roles-configure' })
+  async staffRoleHandler(ctx: ButtonInteraction<'cached'>) {
     const modal = new ModalBuilder()
-      .setTitle('Roles configuration')
-      .setCustomId('@modal/roles-configure');
+      .setTitle('Staff Roles configuration')
+      .setCustomId('@modal/staff-roles-configure');
 
     const rows = [
       new ActionRowBuilder<TextInputBuilder>().addComponents(
@@ -120,8 +139,8 @@ export class Command {
     await ctx.showModal(modal);
   }
 
-  @ModalComponent({ id: '@modal/roles-configure' })
-  async roleModalHandler(ctx: ModalSubmitInteraction<'cached'>) {
+  @ModalComponent({ id: '@modal/staff-roles-configure' })
+  async staffRoleModalHandler(ctx: ModalSubmitInteraction<'cached'>) {
     const [eventsmodeRoleId, coachRoleId, curatorRoleId, moderatorRoleId, adminRoleId] = [
       '@modal/field-eventsmode-id',
       '@modal/field-coach-id',
@@ -138,7 +157,56 @@ export class Command {
       adminRoleId,
     });
 
-    await ctx.reply({ content: 'All roles are successfully configured', ephemeral: true });
+    await ctx.reply({ content: 'Staff roles are successfully configured', ephemeral: true });
+
+    return;
+  }
+
+  @ButtonComponent({ id: '@button/secondary-roles-configure' })
+  async secondaryRoleHandler(ctx: ButtonInteraction<'cached'>) {
+    const modal = new ModalBuilder()
+      .setTitle('Secondary Roles configuration')
+      .setCustomId('@modal/secondary-roles-configure');
+
+    const rows = [
+      new ActionRowBuilder<TextInputBuilder>().addComponents(
+        new TextInputBuilder()
+          .setCustomId('@modal/field-announcement-id')
+          .setLabel('Announcement Role Id')
+          .setStyle(TextInputStyle.Short)
+          .setMinLength(18)
+          .setMaxLength(20),
+      ),
+    ];
+
+    const guild = await Guild.findOneBy({ id: ctx.guild.id });
+
+    if (guild && guild.settingsManagement.announcementRoleId) {
+      const { announcementRoleId } = guild.settingsManagement;
+
+      const roleIds = [announcementRoleId];
+
+      for (const [index, row] of rows.entries()) {
+        row.components[0].setValue(roleIds[index]);
+        row.components[0].setPlaceholder(roleIds[index]);
+      }
+    }
+
+    modal.addComponents(rows);
+    await ctx.showModal(modal);
+  }
+
+  @ModalComponent({ id: '@modal/secondary-roles-configure' })
+  async secondaryRoleModalHandler(ctx: ModalSubmitInteraction<'cached'>) {
+    const [announcementRoleId] = ['@modal/field-announcement-id'].map((id) =>
+      ctx.fields.getTextInputValue(id),
+    );
+
+    await this.settingsManagementService.createOrUpdateRoles(ctx.guild.id, {
+      announcementRoleId,
+    });
+
+    await ctx.reply({ content: 'Secondary roles are successfully configured', ephemeral: true });
 
     return;
   }

--- a/src/feature/guild/settings-management/settings-management.entity.ts
+++ b/src/feature/guild/settings-management/settings-management.entity.ts
@@ -50,6 +50,9 @@ export class SettingsManagement extends BaseEntity {
   adminRoleId: Snowflake;
 
   @Column('text', { nullable: true })
+  announcementRoleId: Snowflake;
+
+  @Column('text', { nullable: true })
   eventsmodeCategoryId: Snowflake;
 
   @Column('text', { nullable: true })

--- a/src/feature/guild/settings-management/settings-management.service.ts
+++ b/src/feature/guild/settings-management/settings-management.service.ts
@@ -6,11 +6,12 @@ import { Database } from '../../../database/data-source.js';
 import { SettingsManagement } from './settings-management.entity.js';
 
 interface RoleObject {
-  eventsmodeRoleId: Snowflake;
-  coachRoleId: Snowflake;
-  curatorRoleId: Snowflake;
-  moderatorRoleId: Snowflake;
-  adminRoleId: Snowflake;
+  eventsmodeRoleId?: Snowflake;
+  coachRoleId?: Snowflake;
+  curatorRoleId?: Snowflake;
+  moderatorRoleId?: Snowflake;
+  adminRoleId?: Snowflake;
+  announcementRoleId?: Snowflake;
 }
 
 interface ChannelsObject {


### PR DESCRIPTION
- **FIXED**: Resolved an issue where the bot would give an error if a user didn't have an avatar. Now, a default avatar is used when none is available.
- **ADDED**: Introduced customization for a special role that must be mentioned when publishing announcements.
- **UPDATED**: Role customization, previously designed for 5 roles via `ModalBuilder`, has been expanded. With the addition of a 6th role, the categories have been split into "Staff Roles" and "Secondary Roles" to overcome the `ModalBuilder` field limit.
- **UPDATED**: Announcements are now published via `EmbedBuilder` instead of JSON, with role mentions included in the announcement embed.